### PR TITLE
[WIP] Remove /dashboard/ route

### DIFF
--- a/components/dashboard-menu.js
+++ b/components/dashboard-menu.js
@@ -6,9 +6,9 @@ const DashboardMenu = () => {
   const router = useRouter()
 
   const menuItems = {
-    Feedstocks: '/dashboard/feedstocks',
-    Bakeries: '/dashboard/bakeries',
-    'Recipe-Runs': '/dashboard/recipe-runs',
+    Feedstocks: '/feedstocks',
+    Bakeries: '/bakeries',
+    'Recipe-Runs': '/recipe-runs',
   }
 
   return (

--- a/components/feedstock-card.js
+++ b/components/feedstock-card.js
@@ -14,7 +14,7 @@ const FeedstockCard = ({ props }) => {
   } = useRepo(spec) || {}
   const timeSinceRun = TimeDeltaFormatter(Date.now() - Date.parse(date))
 
-  const href = '/dashboard/feedstock/' + id
+  const href = '/feedstock/' + id
 
   return (
     <Link

--- a/components/layout.js
+++ b/components/layout.js
@@ -21,7 +21,9 @@ const Layout = ({ children, container = true, menu = null }) => {
 
   const headerItems = {
     Home: '/',
-    Dashboard: '/dashboard/feedstocks',
+    Feedstocks: '/feedstocks',
+    Bakeries: '/Bakeries',
+    'Recipe-runs': '/recipe-runs',
     Docs: 'https://pangeo-forge.readthedocs.io/',
     GitHub: 'https://github.com/pangeo-forge',
   }

--- a/components/recipe-run-card.js
+++ b/components/recipe-run-card.js
@@ -57,7 +57,7 @@ const RecipeRunCard = ({ props }) => {
     Date.now() - Date.parse(started_at + 'Z')
   )
 
-  const href = '/dashboard/recipe-run/' + id
+  const href = '/recipe-run/' + id
 
   return (
     <Link

--- a/pages/bakeries.js
+++ b/pages/bakeries.js
@@ -1,7 +1,7 @@
 import useSWR from 'swr'
-import { Box, Grid, Link } from 'theme-ui'
-import Layout from '../../components/layout'
-import BakeryCard from '../../components/bakery-card'
+import { Box, Grid } from 'theme-ui'
+import Layout from '../components/layout'
+import BakeryCard from '../components/bakery-card'
 
 const fetcher = (url) => fetch(url).then((r) => r.json())
 

--- a/pages/feedstock/[id].js
+++ b/pages/feedstock/[id].js
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router'
 import { Box, Button, Themed, Link } from 'theme-ui'
-import Layout from '../../../components/layout'
-import RecipeRunCard from '../../../components/recipe-run-card'
-import { useFeedstock, useMeta } from '../../../lib/endpoints'
+import Layout from '../../components/layout'
+import RecipeRunCard from '../../components/recipe-run-card'
+import { useFeedstock, useMeta } from '../../lib/endpoints'
 
 const Feedstock = () => {
   const router = useRouter()

--- a/pages/feedstocks.js
+++ b/pages/feedstocks.js
@@ -1,7 +1,7 @@
 import { Box, Grid } from 'theme-ui'
-import Layout from '../../components/layout'
-import FeedstockCard from '../../components/feedstock-card'
-import { useFeedstocks } from '../../lib/endpoints'
+import Layout from '../components/layout'
+import FeedstockCard from '../components/feedstock-card'
+import { useFeedstocks } from '../lib/endpoints'
 
 const Feedstocks = () => {
   const { feedstocks, feedstocksError } = useFeedstocks()

--- a/pages/recipe-run/[id].js
+++ b/pages/recipe-run/[id].js
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { Box, Themed } from 'theme-ui'
-import Layout from '../../../components/layout'
-import { useRecipeRun } from '../../../lib/endpoints'
+import Layout from '../../components/layout'
+import { useRecipeRun } from '../../lib/endpoints'
 
 const RecipeRun = () => {
   const router = useRouter()

--- a/pages/recipe-runs.js
+++ b/pages/recipe-runs.js
@@ -1,7 +1,7 @@
 import { Box } from 'theme-ui'
-import Layout from '../../components/layout'
-import RecipeRunCard from '../../components/recipe-run-card'
-import { useRecipeRuns } from '../../lib/endpoints'
+import Layout from '../components/layout'
+import RecipeRunCard from '../components/recipe-run-card'
+import { useRecipeRuns } from '../lib/endpoints'
 
 const RecipeRuns = () => {
   const { recipeRuns, recipeRunsError } = useRecipeRuns()


### PR DESCRIPTION
This PR removes the /dashboard/ route and puts the feedstocks, bakeries, and recipe-runs routes at the top level of the site. We are still discussing the ideal routing layout (see #14) so this is just a proof-of-concept at this point.