### PR TITLE
refreshInterval for all SWR hooks

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -6,7 +6,8 @@ export const orchestratorEndpoint = 'api.pangeo-forge.org'
 export const useFeedstocks = () => {
   const { data, error } = useSWR(
     `https://${orchestratorEndpoint}/feedstocks/`,
-    jsonFetcher
+    jsonFetcher,
+    { refreshInterval: 300000 }
   )
   return {
     feedstocks: data,
@@ -17,7 +18,8 @@ export const useFeedstocks = () => {
 export const useFeedstock = (id) => {
   const { data, error } = useSWR(
     id ? `https://${orchestratorEndpoint}/feedstocks/${id}` : null,
-    jsonFetcher
+    jsonFetcher,
+    { refreshInterval: 300000 }
   )
   return {
     fs: data,
@@ -28,7 +30,8 @@ export const useFeedstock = (id) => {
 export const useBakeries = () => {
   const { data, error } = useSWR(
     `https://${orchestratorEndpoint}/bakeries/`,
-    jsonFetcher
+    jsonFetcher,
+    { refreshInterval: 3600000 }
   )
   return {
     bakeries: data,
@@ -39,7 +42,8 @@ export const useBakeries = () => {
 export const useBakery = (id) => {
   const { data, error } = useSWR(
     id ? `https://${orchestratorEndpoint}/bakeries/${id}` : null,
-    jsonFetcher
+    jsonFetcher,
+    { refreshInterval: 3600000 }
   )
   return {
     bakery: data,
@@ -50,7 +54,8 @@ export const useBakery = (id) => {
 export const useRecipeRuns = () => {
   const { data, error } = useSWR(
     `https://${orchestratorEndpoint}/recipe_runs/`,
-    jsonFetcher
+    jsonFetcher,
+    { refreshInterval: 10000 }
   )
   return {
     recipeRuns: data,
@@ -61,7 +66,8 @@ export const useRecipeRuns = () => {
 export const useRecipeRun = (id) => {
   const { data, error } = useSWR(
     id ? `https://${orchestratorEndpoint}/recipe_runs/${id}` : null,
-    jsonFetcher
+    jsonFetcher,
+    { refreshInterval: 10000 }
   )
   return {
     recipeRun: data,
@@ -72,7 +78,8 @@ export const useRecipeRun = (id) => {
 export const useStats = (key) => {
   const { data, error } = useSWR(
     key ? `https://${orchestratorEndpoint}/stats/${key}` : null,
-    jsonFetcher
+    jsonFetcher,
+    { refreshInterval: 600000 }
   )
   return {
     stat: data,
@@ -104,8 +111,14 @@ export const useMeta = (spec) => {
   }
 }
 
-export const usePrefect = (id) => {
-  const { data, error } = useSWR(`/api/prefect/${id}`, yamlFetcher)
+export const usePrefect = (id, active = true) => {
+  let options = {}
+
+  if (active) {
+    options = { refreshInterval: 1000 }
+  }
+
+  const { data, error } = useSWR(`/api/prefect/${id}`, jsonFetcher, options)
   return {
     prefect: data,
     prefectError: error,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1368,14 +1368,14 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
-      "integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+      "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.13.0",
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/typescript-estree": "5.13.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1395,13 +1395,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
-      "integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+      "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/visitor-keys": "5.13.0"
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1412,9 +1412,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
-      "integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+      "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1425,13 +1425,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
-      "integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+      "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/visitor-keys": "5.13.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -1467,12 +1467,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
-      "integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+      "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/types": "5.14.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -1909,13 +1909,13 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-      "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
+      "integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
       "peer": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001312",
-        "electron-to-chromium": "^1.4.71",
+        "caniuse-lite": "^1.0.30001313",
+        "electron-to-chromium": "^1.4.76",
         "escalade": "^3.1.1",
         "node-releases": "^2.0.2",
         "picocolors": "^1.0.0"
@@ -1959,9 +1959,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+      "version": "1.0.30001313",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
+      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -2125,9 +2125,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.75",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
-      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
+      "version": "1.4.76",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
+      "integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==",
       "peer": true
     },
     "node_modules/emoji-regex": {
@@ -2247,9 +2247,9 @@
       "dev": true
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz",
-      "integrity": "sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+      "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -2565,9 +2565,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz",
-      "integrity": "sha512-ypEBTKOy5liFQXZWMchJ3LN0JX1uPI6n7MN7OPHKacqXAxq5gYC30TdO7wqGYQyxD1OrzpobdHC3hDmlRWDg9w==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
+      "integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -5847,9 +5847,9 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.13.0.tgz",
+      "integrity": "sha512-nWuffZppoaYK0vQ1SQmkSsQzJoHA4s6uzdb2waRpD806x9yfq153AdVsWz4je2qZcW+pENrMQXbGQ3sMCkXuhw==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
@@ -6032,9 +6032,9 @@
       }
     },
     "node_modules/unist-util-stringify-position": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.1.tgz",
-      "integrity": "sha512-HDVOJ704Uj5QWqoB6KV4CDP62OW9wam9BEuwGE4fvunhVraZcO/fFNBCpvmDDSlkFBG/GAYdHfKvKvDAJxzcWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+      "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -6118,9 +6118,9 @@
       "dev": true
     },
     "node_modules/vfile": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.1.tgz",
-      "integrity": "sha512-EWkoULWVDBV3ozmE21TA0qekXreWJXV1jKcF8rgnvmmH0L9Vm8eTSnuuSSpH2XpLXZLJ0uMMIHUqDLHjK5lh4w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+      "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -6133,9 +6133,9 @@
       }
     },
     "node_modules/vfile-message": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.1.tgz",
-      "integrity": "sha512-pz5xA88aupQPuXmY46xnGAv8MzAcU1Xi2Do3UftjTdvQHreXCWvJT/BbzYixPNYRek+EAioI0kP3crJu37xa6Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+      "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -6164,9 +6164,9 @@
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "node_modules/webpack": {
-      "version": "5.69.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
-      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
+      "version": "5.70.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+      "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -6178,7 +6178,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.8.3",
+        "enhanced-resolve": "^5.9.2",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -7358,41 +7358,41 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@typescript-eslint/parser": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
-      "integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+      "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.13.0",
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/typescript-estree": "5.13.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
-      "integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+      "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/visitor-keys": "5.13.0"
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
-      "integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+      "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
-      "integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+      "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.13.0",
-        "@typescript-eslint/visitor-keys": "5.13.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -7412,12 +7412,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
-      "integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+      "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.13.0",
+        "@typescript-eslint/types": "5.14.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -7779,13 +7779,13 @@
       }
     },
     "browserslist": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-      "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
+      "integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
       "peer": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001312",
-        "electron-to-chromium": "^1.4.71",
+        "caniuse-lite": "^1.0.30001313",
+        "electron-to-chromium": "^1.4.76",
         "escalade": "^3.1.1",
         "node-releases": "^2.0.2",
         "picocolors": "^1.0.0"
@@ -7813,9 +7813,9 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+      "version": "1.0.30001313",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
+      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q=="
     },
     "ccount": {
       "version": "2.0.1",
@@ -7933,9 +7933,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -8013,9 +8013,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.75",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
-      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
+      "version": "1.4.76",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
+      "integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==",
       "peer": true
     },
     "emoji-regex": {
@@ -8025,9 +8025,9 @@
       "dev": true
     },
     "enhanced-resolve": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz",
-      "integrity": "sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+      "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
       "peer": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -8341,9 +8341,9 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz",
-      "integrity": "sha512-ypEBTKOy5liFQXZWMchJ3LN0JX1uPI6n7MN7OPHKacqXAxq5gYC30TdO7wqGYQyxD1OrzpobdHC3hDmlRWDg9w==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
+      "integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -10530,9 +10530,9 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.13.0.tgz",
+      "integrity": "sha512-nWuffZppoaYK0vQ1SQmkSsQzJoHA4s6uzdb2waRpD806x9yfq153AdVsWz4je2qZcW+pENrMQXbGQ3sMCkXuhw==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
@@ -10663,9 +10663,9 @@
       }
     },
     "unist-util-stringify-position": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.1.tgz",
-      "integrity": "sha512-HDVOJ704Uj5QWqoB6KV4CDP62OW9wam9BEuwGE4fvunhVraZcO/fFNBCpvmDDSlkFBG/GAYdHfKvKvDAJxzcWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+      "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
       "requires": {
         "@types/unist": "^2.0.0"
       }
@@ -10728,9 +10728,9 @@
       "dev": true
     },
     "vfile": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.1.tgz",
-      "integrity": "sha512-EWkoULWVDBV3ozmE21TA0qekXreWJXV1jKcF8rgnvmmH0L9Vm8eTSnuuSSpH2XpLXZLJ0uMMIHUqDLHjK5lh4w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+      "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -10739,9 +10739,9 @@
       }
     },
     "vfile-message": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.1.tgz",
-      "integrity": "sha512-pz5xA88aupQPuXmY46xnGAv8MzAcU1Xi2Do3UftjTdvQHreXCWvJT/BbzYixPNYRek+EAioI0kP3crJu37xa6Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+      "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -10763,9 +10763,9 @@
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "webpack": {
-      "version": "5.69.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
-      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
+      "version": "5.70.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+      "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
       "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -10777,7 +10777,7 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.8.3",
+        "enhanced-resolve": "^5.9.2",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/pages/dashboard/recipe-run/[id].js
+++ b/pages/dashboard/recipe-run/[id].js
@@ -55,7 +55,14 @@ const RecipeRun = () => {
   const { id } = router.query
 
   const { recipeRun, recipeRunError } = useRecipeRun(id)
-  const { prefect, prefectError } = usePrefect(id)
+
+  let active = false
+
+  if (recipeRun) {
+    active = recipeRun.status != 'completed'
+  }
+
+  const { prefect, prefectError } = usePrefect(id, active)
 
   if (recipeRunError) {
     return (


### PR DESCRIPTION
towards #26 

This adds the `refreshInterval` option for all hooks. This controls how often we look for new data. I've conditioned the prefect log fetch to only be active when the recipe run in an active state. These are easy to tune so if we want to throttle back any of the defaults, we can do that.

cc @cisaacstern - this should fix the problem where the prefect logs seem to get stuck.