### PR TITLE
exclude test runs from reported number of datasets

### DIFF
--- a/src/components/dashboard/summary.js
+++ b/src/components/dashboard/summary.js
@@ -38,7 +38,7 @@ export const Summary = () => {
   const borderColor = useColorModeValue('gray.800', 'gray.500')
   const feedstocks = useStats('feedstocks')
   const recipeRuns = useStats('recipe_runs')
-  const datasets = useStats('datasets')
+  const datasets = useStats('datasets?exclude_test_runs=true')
 
   const reports = [
     { label: 'Feedstocks', href: '/dashboard/feedstocks', stats: feedstocks },


### PR DESCRIPTION
This uses the new query parameter introduced in https://github.com/pangeo-forge/pangeo-forge-orchestrator/pull/72 to filter out test runs 