### PR TITLE
Variablize orchestratorEndpoint via query param

### DIFF
--- a/components/feedstock-card.js
+++ b/components/feedstock-card.js
@@ -1,5 +1,5 @@
 import { Box } from 'theme-ui'
-import Link from 'next/link'
+import { LinkWithQuery } from '../lib/link'
 import { useRepo } from '../lib/endpoints'
 import { GoMarkGithub } from 'react-icons/go'
 import { TimeDeltaFormatter } from '../lib/time-delta'
@@ -16,7 +16,7 @@ const FeedstockCard = ({ props }) => {
   const href = '/dashboard/feedstock/' + id
 
   return (
-    <Link
+    <LinkWithQuery
       href={href}
       passHref
       sx={{
@@ -83,7 +83,7 @@ const FeedstockCard = ({ props }) => {
           </Box>
         </Box>
       </Box>
-    </Link>
+    </LinkWithQuery>
   )
 }
 

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -1,11 +1,19 @@
 import useSWR from 'swr'
 import { jsonFetcher, yamlFetcher } from './fetchers'
+import { useRouter } from 'next/router'
 
-export const orchestratorEndpoint = 'api.pangeo-forge.org'
+function getOrchestratorEndpoint() {
+  const { query } = useRouter()
+  let endpoint = 'api.pangeo-forge.org'
+  if ('orchestratorEndpoint' in query) {
+    endpoint = query.orchestratorEndpoint
+  }
+  return endpoint
+}
 
 export const useFeedstocks = () => {
   const { data, error } = useSWR(
-    `https://${orchestratorEndpoint}/feedstocks/`,
+    `https://${getOrchestratorEndpoint()}/feedstocks/`,
     jsonFetcher,
     { refreshInterval: 300000 }
   )
@@ -17,7 +25,7 @@ export const useFeedstocks = () => {
 
 export const useFeedstock = (id) => {
   const { data, error } = useSWR(
-    id ? `https://${orchestratorEndpoint}/feedstocks/${id}` : null,
+    id ? `https://${getOrchestratorEndpoint()}/feedstocks/${id}` : null,
     jsonFetcher,
     { refreshInterval: 300000 }
   )
@@ -29,7 +37,7 @@ export const useFeedstock = (id) => {
 
 export const useBakeries = () => {
   const { data, error } = useSWR(
-    `https://${orchestratorEndpoint}/bakeries/`,
+    `https://${getOrchestratorEndpoint()}/bakeries/`,
     jsonFetcher,
     { refreshInterval: 3600000 }
   )
@@ -41,7 +49,7 @@ export const useBakeries = () => {
 
 export const useBakery = (id) => {
   const { data, error } = useSWR(
-    id ? `https://${orchestratorEndpoint}/bakeries/${id}` : null,
+    id ? `https://${getOrchestratorEndpoint()}/bakeries/${id}` : null,
     jsonFetcher,
     { refreshInterval: 3600000 }
   )
@@ -53,7 +61,7 @@ export const useBakery = (id) => {
 
 export const useRecipeRuns = () => {
   const { data, error } = useSWR(
-    `https://${orchestratorEndpoint}/recipe_runs/`,
+    `https://${getOrchestratorEndpoint()}/recipe_runs/`,
     jsonFetcher,
     { refreshInterval: 10000 }
   )
@@ -65,7 +73,7 @@ export const useRecipeRuns = () => {
 
 export const useRecipeRun = (id) => {
   const { data, error } = useSWR(
-    id ? `https://${orchestratorEndpoint}/recipe_runs/${id}` : null,
+    id ? `https://${getOrchestratorEndpoint()}/recipe_runs/${id}` : null,
     jsonFetcher,
     { refreshInterval: 10000 }
   )
@@ -77,7 +85,7 @@ export const useRecipeRun = (id) => {
 
 export const useStats = (key) => {
   const { data, error } = useSWR(
-    key ? `https://${orchestratorEndpoint}/stats/${key}` : null,
+    key ? `https://${getOrchestratorEndpoint()}/stats/${key}` : null,
     jsonFetcher,
     { refreshInterval: 600000 }
   )

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -2,7 +2,7 @@ import useSWR from 'swr'
 import { jsonFetcher, yamlFetcher } from './fetchers'
 import { useRouter } from 'next/router'
 
-function getOrchestratorEndpoint() {
+function useOrchestratorEndpoint() {
   const { query } = useRouter()
   let endpoint = 'api.pangeo-forge.org'
   if ('orchestratorEndpoint' in query) {
@@ -12,8 +12,9 @@ function getOrchestratorEndpoint() {
 }
 
 export const useFeedstocks = () => {
+  const orchestratorEndpoint = useOrchestratorEndpoint()
   const { data, error } = useSWR(
-    `https://${getOrchestratorEndpoint()}/feedstocks/`,
+    `https://${orchestratorEndpoint}/feedstocks/`,
     jsonFetcher,
     { refreshInterval: 300000 }
   )
@@ -24,8 +25,9 @@ export const useFeedstocks = () => {
 }
 
 export const useFeedstock = (id) => {
+  const orchestratorEndpoint = useOrchestratorEndpoint()
   const { data, error } = useSWR(
-    id ? `https://${getOrchestratorEndpoint()}/feedstocks/${id}` : null,
+    id ? `https://${orchestratorEndpoint}/feedstocks/${id}` : null,
     jsonFetcher,
     { refreshInterval: 300000 }
   )
@@ -36,8 +38,9 @@ export const useFeedstock = (id) => {
 }
 
 export const useBakeries = () => {
+  const orchestratorEndpoint = useOrchestratorEndpoint()
   const { data, error } = useSWR(
-    `https://${getOrchestratorEndpoint()}/bakeries/`,
+    `https://${orchestratorEndpoint}/bakeries/`,
     jsonFetcher,
     { refreshInterval: 3600000 }
   )
@@ -48,8 +51,9 @@ export const useBakeries = () => {
 }
 
 export const useBakery = (id) => {
+  const orchestratorEndpoint = useOrchestratorEndpoint()
   const { data, error } = useSWR(
-    id ? `https://${getOrchestratorEndpoint()}/bakeries/${id}` : null,
+    id ? `https://${orchestratorEndpoint}/bakeries/${id}` : null,
     jsonFetcher,
     { refreshInterval: 3600000 }
   )
@@ -60,8 +64,9 @@ export const useBakery = (id) => {
 }
 
 export const useRecipeRuns = () => {
+  const orchestratorEndpoint = useOrchestratorEndpoint()
   const { data, error } = useSWR(
-    `https://${getOrchestratorEndpoint()}/recipe_runs/`,
+    `https://${useOrchestratorEndpoint()}/recipe_runs/`,
     jsonFetcher,
     { refreshInterval: 10000 }
   )
@@ -72,8 +77,9 @@ export const useRecipeRuns = () => {
 }
 
 export const useRecipeRun = (id) => {
+  const orchestratorEndpoint = useOrchestratorEndpoint()
   const { data, error } = useSWR(
-    id ? `https://${getOrchestratorEndpoint()}/recipe_runs/${id}` : null,
+    id ? `https://${orchestratorEndpoint}/recipe_runs/${id}` : null,
     jsonFetcher,
     { refreshInterval: 10000 }
   )
@@ -84,8 +90,9 @@ export const useRecipeRun = (id) => {
 }
 
 export const useStats = (key) => {
+  const orchestratorEndpoint = useOrchestratorEndpoint()
   const { data, error } = useSWR(
-    key ? `https://${getOrchestratorEndpoint()}/stats/${key}` : null,
+    key ? `https://${orchestratorEndpoint}/stats/${key}` : null,
     jsonFetcher,
     { refreshInterval: 600000 }
   )

--- a/lib/link.js
+++ b/lib/link.js
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export const LinkWithQuery = ({ children, href, ...props }) => {
+  const { query } = useRouter()
+  let paramsToAppend = ''
+  if ('orchestratorEndpoint' in query) {
+    paramsToAppend = `?orchestratorEndpoint=${query.orchestratorEndpoint}`
+  }
+  return (
+    <Link href={href + paramsToAppend} {...props}>
+      {children}
+    </Link>
+  )
+}


### PR DESCRIPTION
This PR introduces an `orchestratorEndpoint` query param. If omitted, the default `api.pangeo-forge.org` is used. If provided, the provided value is used for the orchestrator backend endpoint.

By subclassing `Link` via an adaptation of the code provided in https://typeofnan.dev/how-to-preserve-query-parameters-in-react-router-links/, we can carry over this query parameter from page-to-page.

This feature is primarily useful for development of the backend, so that we can see how changes look here.

It may be appropriate to add a warning banner on the top of the page if a non-default backend is being used, so that users don't mistake a development page they've stumbled on for the production site. I will look into that.