### PR TITLE
Add License component

### DIFF
--- a/src/components/dashboard/feedstock-info.js
+++ b/src/components/dashboard/feedstock-info.js
@@ -1,5 +1,5 @@
 import { Link } from '@/components'
-import { Maintainers, Providers } from '@/components/dashboard'
+import { License, Maintainers, Providers } from '@/components/dashboard'
 import {
   Box,
   Button,
@@ -24,6 +24,7 @@ export const FeedstockInfo = ({
   pangeo_notebook_version,
   bakery,
   license,
+  license_link,
   providers,
   maintainers,
 }) => {
@@ -43,7 +44,7 @@ export const FeedstockInfo = ({
       </Flex>
     ),
     Bakery: bakery,
-    License: license,
+    License: <License name={license} link={license_link} />,
     Providers: <Providers providers={providers} />,
     Maintainers: <Maintainers maintainers={maintainers} />,
   }

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -4,6 +4,7 @@ export { FeedstockCard } from '@/components/dashboard/feedstock-card'
 export { FeedstockDatasets } from '@/components/dashboard/feedstock-datasets'
 export { FeedstockInfo } from '@/components/dashboard/feedstock-info'
 export { FlowRunsAccordion } from '@/components/dashboard/flow-runs-accordion'
+export { License } from '@/components/dashboard/license'
 export { LogLine } from '@/components/dashboard/log-line'
 export {
   Maintainers,

--- a/src/components/dashboard/license.js
+++ b/src/components/dashboard/license.js
@@ -1,4 +1,6 @@
 import { Link } from '@/components'
+import { Flex, Icon, Text } from '@chakra-ui/react'
+import { VscLaw } from 'react-icons/vsc'
 
 export const License = ({ name, link }) => {
   const href =
@@ -7,8 +9,11 @@ export const License = ({ name, link }) => {
   const text = name === 'proprietary' ? link?.title : name
 
   return (
-    <Link href={href} useExternalIcon>
-      {text}
-    </Link>
+    <Flex>
+      <Icon as={VscLaw} fontSize={'2xl'} />
+      <Text as={Link} href={href} useExternalIcon px={2}>
+        {text}
+      </Text>
+    </Flex>
   )
 }

--- a/src/components/dashboard/license.js
+++ b/src/components/dashboard/license.js
@@ -1,0 +1,14 @@
+import { Link } from '@/components'
+
+export const License = ({ name, link }) => {
+  const href =
+    name === 'proprietary' ? link?.url : `https://spdx.org/licenses/${name}`
+
+  const text = name === 'proprietary' ? link?.title : name
+
+  return (
+    <Link href={href} useExternalIcon>
+      {text}
+    </Link>
+  )
+}

--- a/src/components/dashboard/license.js
+++ b/src/components/dashboard/license.js
@@ -1,6 +1,5 @@
 import { Link } from '@/components'
-import { Flex, Icon, Text } from '@chakra-ui/react'
-import { VscLaw } from 'react-icons/vsc'
+import { Text } from '@chakra-ui/react'
 
 export const License = ({ name, link }) => {
   const href =
@@ -9,11 +8,10 @@ export const License = ({ name, link }) => {
   const text = name === 'proprietary' ? link?.title : name
 
   return (
-    <Flex>
-      <Icon as={VscLaw} fontSize={'2xl'} />
-      <Text as={Link} href={href} useExternalIcon px={2}>
+    <>
+      <Text as={Link} href={href} useExternalIcon>
         {text}
       </Text>
-    </Flex>
+    </>
   )
 }

--- a/src/pages/dashboard/feedstock/[id].js
+++ b/src/pages/dashboard/feedstock/[id].js
@@ -60,6 +60,7 @@ const Feedstock = () => {
               pangeo_notebook_version={meta?.pangeo_notebook_version}
               bakery={meta?.bakery?.id}
               license={meta?.provenance?.license}
+              license_link={meta?.provenance?.license_link}
               providers={meta?.provenance?.providers}
               maintainers={meta?.maintainers}
             />

--- a/src/pages/dashboard/recipe-run/[id].js
+++ b/src/pages/dashboard/recipe-run/[id].js
@@ -80,6 +80,7 @@ const RecipeRun = () => {
               pangeo_notebook_version={meta?.pangeo_notebook_version}
               bakery={meta?.bakery?.id}
               license={meta?.provenance?.license}
+              license_link={meta?.provenance?.license_link}
               providers={meta?.provenance?.providers}
               maintainers={meta?.maintainers}
             />


### PR DESCRIPTION
- This PR implements @rabernat's suggestion in  https://github.com/pangeo-forge/staged-recipes/pull/156#issuecomment-1188085479
	- Adds link to https://spdx.github.io/license-list-data/ for any license with a valid SPDX identifier (e.g. https://pangeo-forge-mohvxfy5u-pangeo-forge.vercel.app/dashboard/feedstock/2)
    - For proprietary licenses, we link to the external license link. 

> **Note**
We need to update feedstocks that produce data with proprietary licenses

- https://github.com/pangeo-forge/CMIP6_static_grids-feedstock
- https://github.com/pangeo-forge/gpcp-feedstock
- https://github.com/pangeo-forge/HadISST-feedstock
