### PR TITLE
Fix `orchestratorEndpoint` variable bug

### DIFF
--- a/src/lib/endpoints.js
+++ b/src/lib/endpoints.js
@@ -2,7 +2,7 @@ import { jsonFetcher, yamlFetcher } from '@/lib/fetchers'
 import { useRouter } from 'next/router'
 import useSWR from 'swr'
 
-function useOrchestratorEndpoint() {
+export function useOrchestratorEndpoint() {
   const { query } = useRouter()
   const endpoint = query?.orchestratorEndpoint || 'api.pangeo-forge.org'
   return endpoint

--- a/src/pages/api/prefect/[id].js
+++ b/src/pages/api/prefect/[id].js
@@ -1,4 +1,3 @@
-import { orchestratorEndpoint } from '@/lib/endpoints'
 import {
   ApolloClient,
   InMemoryCache,
@@ -6,6 +5,8 @@ import {
   gql,
 } from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
+
+const orchestratorEndpoint = 'api.pangeo-forge.org'
 
 const QUERY = gql`
   query FlowRun($name: String!) {


### PR DESCRIPTION
This PR fixes a bug that was silently introduced in 
- https://github.com/pangeo-forge/pangeo-forge.org/pull/143

This bug was preventing Prefect logs from being properly fetched and displayed:

- https://pangeo-forge.org/dashboard/recipe-run/999?feedstock_id=43 (doesn't work)
- https://pangeo-forge-hdvpe2pd3-pangeo-forge.vercel.app/dashboard/recipe-run/999?feedstock_id=43 (works)

This PR hardcodes the `orchestratorEndpoint` used when querying prefect cloud because the `useOrchestratorEndpoint()` hook cannot be used outside of react component. 

