### PR TITLE
fix bug when parsing dataset name from url that has a trailing slash

### DIFF
--- a/src/components/dashboard/datasets-accordion.js
+++ b/src/components/dashboard/datasets-accordion.js
@@ -32,8 +32,10 @@ const DatasetRepr = ({ dataset }) => {
 }
 
 export const DatasetCard = ({ dataset }) => {
-  const parts = dataset.split('/')
-  const name = parts[parts.length - 1]
+  const name = dataset
+    .split('/')
+    .filter((elem) => elem)
+    .slice(-1)
   const code = `import xarray as xr
 
 store = '${dataset}'


### PR DESCRIPTION
This PR addresses a bug when the url has a trailing slash